### PR TITLE
Fix 500 when creating a task

### DIFF
--- a/services/provider-tasking/app/schemas.py
+++ b/services/provider-tasking/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List, Literal
 from datetime import datetime
 from uuid import UUID
@@ -29,6 +29,8 @@ class TaskCreate(BaseModel):
     sla_due_at: Optional[datetime] = None
 
 class TaskOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     order_item_id: str
     service_type: str


### PR DESCRIPTION
## Summary
- allow TaskOut response model to be created from ORM objects by enabling Pydantic's attribute parsing
- prevent the task creation endpoint from returning a 500 when returning SQLAlchemy Task instances

## Testing
- python - <<'PY'
import sys
sys.path.append('services/provider-tasking')
from app.schemas import TaskOut
from datetime import datetime
from uuid import uuid4

class Dummy:
    def __init__(self):
        self.id = uuid4()
        self.order_item_id = '123'
        self.service_type = 'test'
        self.provider_id = None
        self.location = None
        self.flight = None
        self.customer_hint = None
        self.status = 'new'
        self.checklist = None
        self.sla_due_at = None
        self.created_at = datetime.utcnow()
        self.updated_at = datetime.utcnow()

TaskOut.model_validate(Dummy())
PY

------
https://chatgpt.com/codex/tasks/task_e_68c90b2a25bc8320beac321b958f1f25