### PR TITLE
Serialize datetimes in JSON task fields

### DIFF
--- a/services/provider-tasking/app/schemas.py
+++ b/services/provider-tasking/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List, Literal
 from datetime import datetime
 from uuid import UUID
@@ -29,6 +29,8 @@ class TaskCreate(BaseModel):
     sla_due_at: Optional[datetime] = None
 
 class TaskOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     order_item_id: str
     service_type: str

--- a/services/provider-tasking/app/service.py
+++ b/services/provider-tasking/app/service.py
@@ -10,10 +10,10 @@ async def create_task(db: AsyncSession, data: TaskCreate) -> Task:
         order_item_id=data.order_item_id,
         service_type=data.service_type,
         provider_id=data.provider_id,
-        location=data.location.model_dump() if data.location else None,
-        flight=data.flight.model_dump() if data.flight else None,
+        location=data.location.model_dump(mode="json") if data.location else None,
+        flight=data.flight.model_dump(mode="json") if data.flight else None,
         customer_hint=data.customer_hint,
-        checklist=[c.model_dump() for c in (data.checklist or [])],
+        checklist=[c.model_dump(mode="json") for c in (data.checklist or [])],
         sla_due_at=data.sla_due_at,
     )
     db.add(task)


### PR DESCRIPTION
## Summary
- serialize nested location, flight, and checklist payloads with Pydantic's JSON mode so datetime values are JSON compatible

## Testing
- python - <<'PY'
import sys
sys.path.append('services/provider-tasking')
from app.schemas import Location, Flight, ChecklistItem, TaskCreate
from datetime import datetime

payload = TaskCreate(
    order_item_id="task_1",
    service_type="support",
    provider_id="provider",
    location=Location(terminal="T1", zone="Z", gate="G"),
    flight=Flight(iata="AB123", std=datetime(2025,1,1,12,0,0)),
    checklist=[ChecklistItem(key="k", title="t")],
)

print(payload.location.model_dump())
print(payload.location.model_dump(mode="json"))
print(payload.flight.model_dump())
print(payload.flight.model_dump(mode="json"))
print([c.model_dump(mode="json") for c in payload.checklist])
PY

------
https://chatgpt.com/codex/tasks/task_e_68c90b2a25bc8320beac321b958f1f25