### PR TITLE
Ensure tasks use serialized payloads for idempotency

### DIFF
--- a/services/provider-tasking/app/main.py
+++ b/services/provider-tasking/app/main.py
@@ -65,7 +65,13 @@ async def start_task(task_id: UUID, db: AsyncSession = Depends(get_db)):
 
 @app.post("/tasks/{task_id}/scan", response_model=TaskOut)
 async def scan_qr(task_id: UUID, payload: ScanPayload, db: AsyncSession = Depends(get_db)):
-    return await _change_status(db, task_id, TaskStatus.in_progress, "SCANNED", payload.model_dump())
+    return await _change_status(
+        db,
+        task_id,
+        TaskStatus.in_progress,
+        "SCANNED",
+        payload.model_dump(mode="json"),
+    )
 
 
 @app.post("/tasks/{task_id}/complete", response_model=TaskOut)
@@ -75,4 +81,10 @@ async def complete_task(task_id: UUID, db: AsyncSession = Depends(get_db)):
 
 @app.post("/tasks/{task_id}/fail", response_model=TaskOut)
 async def fail_task(task_id: UUID, payload: FailPayload, db: AsyncSession = Depends(get_db)):
-    return await _change_status(db, task_id, TaskStatus.failed, "FAILED", payload.model_dump())
+    return await _change_status(
+        db,
+        task_id,
+        TaskStatus.failed,
+        "FAILED",
+        payload.model_dump(mode="json"),
+    )


### PR DESCRIPTION
## Summary
- serialize location, flight, and checklist data before persisting tasks and reuse the values when enforcing idempotency
- ensure TaskEvent payloads are stored from JSON-ready dictionaries during status transitions
- update status-changing endpoints to pass JSON-mode payloads to service logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96f8786f883208a1ed45bedd624f7