### PR TITLE
Add support for cancelled state and conflict handling

### DIFF
--- a/services/provider-tasking/app/main.py
+++ b/services/provider-tasking/app/main.py
@@ -30,6 +30,8 @@ async def get_tasks(status: List[TaskStatus] = Query(default=[]), db: AsyncSessi
     return tasks
 
 def _handle_transition_error(exc: InvalidStatusTransition) -> HTTPException:
+    """Convert a failed transition into a conflict response."""
+
     return HTTPException(status_code=409, detail=str(exc))
 
 
@@ -43,7 +45,7 @@ async def _change_status(
     try:
         return await service.set_status(db, task_id, new_status, event, payload)
     except InvalidStatusTransition as exc:
-        raise _handle_transition_error(exc)
+        raise _handle_transition_error(exc) from exc
 
 
 # Создать задачу (для демонстрации/seed)

--- a/services/provider-tasking/app/models.py
+++ b/services/provider-tasking/app/models.py
@@ -12,6 +12,7 @@ class TaskStatus(str, enum.Enum):
     in_progress = "in_progress"
     done = "done"
     failed = "failed"
+    cancelled = "cancelled"
 
 class Task(Base):
     __tablename__ = "tasks"

--- a/services/provider-tasking/app/schemas.py
+++ b/services/provider-tasking/app/schemas.py
@@ -38,7 +38,7 @@ class TaskOut(BaseModel):
     location: Optional[Location]
     flight: Optional[Flight]
     customer_hint: Optional[dict]
-    status: Literal["new","assigned","in_progress","done","failed"]
+    status: Literal["new","assigned","in_progress","done","failed","cancelled"]
     checklist: Optional[List[ChecklistItem]]
     sla_due_at: Optional[datetime]
     created_at: datetime

--- a/services/provider-tasking/app/service.py
+++ b/services/provider-tasking/app/service.py
@@ -14,11 +14,12 @@ class InvalidStatusTransition(Exception):
 
 
 ALLOWED_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
-    TaskStatus.new: {TaskStatus.assigned, TaskStatus.failed},
-    TaskStatus.assigned: {TaskStatus.in_progress, TaskStatus.failed},
-    TaskStatus.in_progress: {TaskStatus.done, TaskStatus.failed},
+    TaskStatus.new: {TaskStatus.assigned, TaskStatus.failed, TaskStatus.cancelled},
+    TaskStatus.assigned: {TaskStatus.in_progress, TaskStatus.failed, TaskStatus.cancelled},
+    TaskStatus.in_progress: {TaskStatus.done, TaskStatus.failed, TaskStatus.cancelled},
     TaskStatus.done: set(),
     TaskStatus.failed: set(),
+    TaskStatus.cancelled: set(),
 }
 
 async def create_task(db: AsyncSession, data: TaskCreate) -> Task:

--- a/services/provider-tasking/tests/test_main.py
+++ b/services/provider-tasking/tests/test_main.py
@@ -1,0 +1,35 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from uuid import uuid4
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.main import _change_status
+from app.models import TaskStatus
+from app.service import InvalidStatusTransition
+
+
+class ChangeStatusTests(unittest.TestCase):
+    """Ensure HTTP responses mirror the service error semantics."""
+
+    def test_invalid_transition_results_in_conflict(self) -> None:
+        db = object()
+        task_id = uuid4()
+        error = InvalidStatusTransition(TaskStatus.new, TaskStatus.done)
+
+        async_mock = AsyncMock(side_effect=error)
+
+        with patch("app.main.service.set_status", new=async_mock):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(_change_status(db, task_id, TaskStatus.done, "TEST"))
+
+        self.assertEqual(ctx.exception.status_code, 409)
+        self.assertIs(ctx.exception.__cause__, error)
+

--- a/services/provider-tasking/tests/test_service.py
+++ b/services/provider-tasking/tests/test_service.py
@@ -1,0 +1,22 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.models import TaskStatus
+from app.service import ALLOWED_TRANSITIONS
+
+
+class AllowedTransitionsTests(unittest.TestCase):
+    """Validate the task state machine reflects the upstream configuration."""
+
+    def test_cancelled_state_is_configured(self) -> None:
+        """Tasks should be able to transition into the cancelled state."""
+
+        self.assertIn(TaskStatus.cancelled, ALLOWED_TRANSITIONS[TaskStatus.new])
+        self.assertIn(TaskStatus.cancelled, ALLOWED_TRANSITIONS[TaskStatus.assigned])
+        self.assertIn(TaskStatus.cancelled, ALLOWED_TRANSITIONS[TaskStatus.in_progress])
+        self.assertEqual(set(), ALLOWED_TRANSITIONS[TaskStatus.cancelled])


### PR DESCRIPTION
## Summary
- add the `cancelled` status to the task model/schema and update the transition map to match the upstream state machine
- ensure `_change_status` propagates `InvalidStatusTransition` errors as HTTP 409 responses
- cover the updated state machine and HTTP error handling with unit tests

## Testing
- python -m unittest discover -s services/provider-tasking/tests

------
https://chatgpt.com/codex/tasks/task_e_68c96f8e62688320a2cc47adb28161bd