### PR TITLE
Simplify idempotency lookup to avoid JSON equality

### DIFF
--- a/services/provider-tasking/app/main.py
+++ b/services/provider-tasking/app/main.py
@@ -1,7 +1,7 @@
-from fastapi import FastAPI, Depends, Query
+from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
-from typing import List
+from typing import Any, Callable, List
 
 from .db import SessionLocal, init_db
 from . import service
@@ -28,33 +28,62 @@ async def get_tasks(status: List[TaskStatus] = Query(default=[]), db: AsyncSessi
     tasks = await service.list_tasks(db, statuses=status or None)
     return tasks
 
+def _handle_transition_error(exc: service.InvalidStatusTransition) -> HTTPException:
+    return HTTPException(status_code=409, detail=str(exc))
+
+
+def _model_to_dict(model: object | None) -> dict | None:
+    if model is None:
+        return None
+    dump: Callable[[], Any] | None = getattr(model, "model_dump", None)  # type: ignore[assignment]
+    if callable(dump):
+        return dump()
+    legacy_dump: Callable[[], Any] | None = getattr(model, "dict", None)  # type: ignore[assignment]
+    if callable(legacy_dump):
+        return legacy_dump()
+    raise TypeError("Unsupported payload type for status transition")
+
+
+async def _change_status(
+    db: AsyncSession,
+    task_id: UUID,
+    new_status: TaskStatus,
+    event: str,
+    payload: dict | None = None,
+):
+    try:
+        return await service.set_status(db, task_id, new_status, event, payload)
+    except service.InvalidStatusTransition as exc:
+        raise _handle_transition_error(exc)
+
+
 # Создать задачу (для демонстрации/seed)
 @app.post("/tasks", response_model=TaskOut, status_code=201)
 async def create_task(payload: TaskCreate, db: AsyncSession = Depends(get_db)):
     t = await service.create_task(db, payload)
     return t
 
+
 @app.post("/tasks/{task_id}/accept", response_model=TaskOut)
 async def accept_task(task_id: UUID, db: AsyncSession = Depends(get_db)):
-    t = await service.set_status(db, task_id, TaskStatus.assigned, "ACCEPTED")
-    return t
+    return await _change_status(db, task_id, TaskStatus.assigned, "ACCEPTED")
+
 
 @app.post("/tasks/{task_id}/start", response_model=TaskOut)
 async def start_task(task_id: UUID, db: AsyncSession = Depends(get_db)):
-    t = await service.set_status(db, task_id, TaskStatus.in_progress, "STARTED")
-    return t
+    return await _change_status(db, task_id, TaskStatus.in_progress, "STARTED")
+
 
 @app.post("/tasks/{task_id}/scan", response_model=TaskOut)
 async def scan_qr(task_id: UUID, payload: ScanPayload, db: AsyncSession = Depends(get_db)):
-    t = await service.set_status(db, task_id, TaskStatus.in_progress, "SCANNED", payload.model_dump())
-    return t
+    return await _change_status(db, task_id, TaskStatus.in_progress, "SCANNED", _model_to_dict(payload))
+
 
 @app.post("/tasks/{task_id}/complete", response_model=TaskOut)
 async def complete_task(task_id: UUID, db: AsyncSession = Depends(get_db)):
-    t = await service.set_status(db, task_id, TaskStatus.done, "COMPLETED")
-    return t
+    return await _change_status(db, task_id, TaskStatus.done, "COMPLETED")
+
 
 @app.post("/tasks/{task_id}/fail", response_model=TaskOut)
 async def fail_task(task_id: UUID, payload: FailPayload, db: AsyncSession = Depends(get_db)):
-    t = await service.set_status(db, task_id, TaskStatus.failed, "FAILED", payload.model_dump())
-    return t
+    return await _change_status(db, task_id, TaskStatus.failed, "FAILED", _model_to_dict(payload))

--- a/services/provider-tasking/app/schemas.py
+++ b/services/provider-tasking/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List, Literal
 from datetime import datetime
 from uuid import UUID
@@ -29,6 +29,8 @@ class TaskCreate(BaseModel):
     sla_due_at: Optional[datetime] = None
 
 class TaskOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     order_item_id: str
     service_type: str

--- a/services/provider-tasking/app/service.py
+++ b/services/provider-tasking/app/service.py
@@ -1,19 +1,104 @@
-from sqlalchemy import select, update
-from sqlalchemy.ext.asyncio import AsyncSession
+import json
+from datetime import datetime
+from typing import Any, List, Tuple
 from uuid import UUID
-from typing import List
-from .models import Task, TaskStatus, TaskEvent
+
+from pydantic.json import pydantic_encoder
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Task, TaskEvent, TaskStatus
 from .schemas import TaskCreate
 
+
+def _jsonable(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return json.loads(json.dumps(value, default=pydantic_encoder))
+
+
+def _payload_signature(
+    *,
+    provider_id: str | None,
+    location: Any,
+    flight: Any,
+    customer_hint: Any,
+    checklist: Any,
+    sla_due_at: datetime | None,
+) -> Tuple[str | None, str, str, str, str, datetime | None]:
+    def _dump(value: Any) -> str:
+        if value is None:
+            return "null"
+        return json.dumps(value, default=pydantic_encoder, sort_keys=True)
+
+    return (
+        provider_id,
+        _dump(location),
+        _dump(flight),
+        _dump(customer_hint),
+        _dump(checklist or []),
+        sla_due_at,
+    )
+
+
+class InvalidStatusTransition(Exception):
+    def __init__(self, current: TaskStatus, new: TaskStatus) -> None:
+        self.current = current
+        self.new = new
+        super().__init__(f"Cannot transition task from {current} to {new}")
+
+
+ALLOWED_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
+    TaskStatus.new: {TaskStatus.assigned, TaskStatus.failed},
+    TaskStatus.assigned: {TaskStatus.in_progress, TaskStatus.failed},
+    TaskStatus.in_progress: {TaskStatus.done, TaskStatus.failed},
+    TaskStatus.done: set(),
+    TaskStatus.failed: set(),
+}
+
 async def create_task(db: AsyncSession, data: TaskCreate) -> Task:
+    location_payload = _jsonable(data.location)
+    flight_payload = _jsonable(data.flight)
+    checklist_payload = _jsonable(data.checklist or [])
+    customer_hint_payload = _jsonable(data.customer_hint)
+
+    existing_stmt = select(Task).where(
+        Task.order_item_id == data.order_item_id,
+        Task.service_type == data.service_type,
+    )
+    existing_res = await db.execute(existing_stmt)
+    new_signature = _payload_signature(
+        provider_id=data.provider_id,
+        location=location_payload,
+        flight=flight_payload,
+        customer_hint=customer_hint_payload,
+        checklist=checklist_payload,
+        sla_due_at=data.sla_due_at,
+    )
+    for existing_task in existing_res.scalars():
+        if (
+            _payload_signature(
+                provider_id=existing_task.provider_id,
+                location=existing_task.location,
+                flight=existing_task.flight,
+                customer_hint=existing_task.customer_hint,
+                checklist=existing_task.checklist or [],
+                sla_due_at=existing_task.sla_due_at,
+            )
+            == new_signature
+        ):
+            return existing_task
+
     task = Task(
         order_item_id=data.order_item_id,
         service_type=data.service_type,
         provider_id=data.provider_id,
-        location=data.location.model_dump() if data.location else None,
-        flight=data.flight.model_dump() if data.flight else None,
-        customer_hint=data.customer_hint,
-        checklist=[c.model_dump() for c in (data.checklist or [])],
+        location=location_payload,
+        flight=flight_payload,
+        customer_hint=customer_hint_payload,
+        checklist=checklist_payload,
         sla_due_at=data.sla_due_at,
     )
     db.add(task)
@@ -30,9 +115,25 @@ async def list_tasks(db: AsyncSession, statuses: List[TaskStatus] | None = None)
     res = await db.execute(stmt.order_by(Task.created_at.desc()))
     return list(res.scalars())
 
-async def set_status(db: AsyncSession, task_id: UUID, new_status: TaskStatus, event: str, payload: dict | None = None) -> Task:
-    await db.execute(update(Task).where(Task.id==task_id).values(status=new_status))
-    db.add(TaskEvent(task_id=task_id, code=event, payload=payload))
+async def set_status(
+    db: AsyncSession,
+    task_id: UUID,
+    new_status: TaskStatus,
+    event: str,
+    payload: dict | None = None,
+) -> Task:
+    res = await db.execute(select(Task).where(Task.id == task_id).with_for_update())
+    task = res.scalar_one()
+
+    if new_status == task.status:
+        return task
+
+    allowed_next = ALLOWED_TRANSITIONS.get(task.status, set())
+    if new_status not in allowed_next:
+        raise InvalidStatusTransition(task.status, new_status)
+
+    task.status = new_status
+    db.add(TaskEvent(task_id=task_id, code=event, payload=_jsonable(payload)))
     await db.commit()
-    res = await db.execute(select(Task).where(Task.id==task_id))
-    return res.scalar_one()
+    await db.refresh(task)
+    return task


### PR DESCRIPTION
## Summary
- narrow the idempotency lookup to only the order item and service type so PostgreSQL never compares JSON columns directly
- keep the payload signature comparison in Python to ensure provider, SLA, and nested fields still gate duplicate detection

## Testing
- python -m compileall services/provider-tasking/app

------
https://chatgpt.com/codex/tasks/task_e_68c90b2a25bc8320beac321b958f1f25