### PR TITLE
Add booking lookup service with mock repository

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,5 +40,13 @@ services:
       redis:
         condition: service_healthy
 
+  booking-lookup:
+    image: python:3.12-slim
+    working_dir: /app
+    volumes:
+      - ./services/booking-lookup:/app
+    command: bash -lc "pip install --no-cache-dir -r requirements.txt && uvicorn app.main:app --host 0.0.0.0 --port 8200 --reload"
+    ports: ["8200:8200"]
+
 volumes:
   pg_data:

--- a/services/booking-lookup/.gitignore
+++ b/services/booking-lookup/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/services/booking-lookup/app/__init__.py
+++ b/services/booking-lookup/app/__init__.py
@@ -1,0 +1,1 @@
+"""Booking lookup service package."""

--- a/services/booking-lookup/app/main.py
+++ b/services/booking-lookup/app/main.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("booking_lookup")
+logging.basicConfig(level=logging.INFO)
+
+
+@dataclass(frozen=True)
+class FlightDetails:
+    """Domain entity that represents a flight associated with a booking."""
+
+    iata: str
+    std: datetime
+
+
+@dataclass(frozen=True)
+class BookingRecord:
+    """Domain entity stored in the mock repository."""
+
+    ticket_number: str
+    pnr: str
+    passenger_name: str
+    flight: FlightDetails
+    service_suggestions: tuple[str, ...] = ()
+
+
+class BookingRepository:
+    """Simple in-memory repository for the MVP implementation."""
+
+    def __init__(self, records: Iterable[BookingRecord]):
+        self._index: Dict[str, BookingRecord] = {}
+        for record in records:
+            self._index[record.ticket_number] = record
+            self._index[record.pnr] = record
+
+    def get(self, identifier: str) -> Optional[BookingRecord]:
+        return self._index.get(identifier)
+
+
+class LookupRequest(BaseModel):
+    ticket_or_pnr: str = Field(..., description="Ticket number or PNR to lookup", min_length=1)
+
+
+class FlightSchema(BaseModel):
+    iata: str
+    std: datetime
+
+
+class LookupResponse(BaseModel):
+    passenger_id: str
+    passenger_masked: str
+    ticket_hash: str
+    ticket_last4: str
+    flight_id: str
+    flight: FlightSchema
+    service_suggestions: List[str] = []
+
+
+MOCK_REPOSITORY = BookingRepository(
+    records=[
+        BookingRecord(
+            ticket_number="555-1234567890",
+            pnr="ABC123",
+            passenger_name="Иванов Иван",
+            flight=FlightDetails(iata="SU123", std=datetime.fromisoformat("2025-09-17T10:00:00+00:00")),
+            service_suggestions=("WCHR",),
+        ),
+        BookingRecord(
+            ticket_number="555-9876543210",
+            pnr="XYZ789",
+            passenger_name="Петров Петр",
+            flight=FlightDetails(iata="SU321", std=datetime.fromisoformat("2025-11-05T20:15:00+00:00")),
+            service_suggestions=(),
+        ),
+    ]
+)
+
+app = FastAPI(title="Booking Lookup Service", version="0.1.0")
+
+
+def mask_passenger_name(full_name: str) -> str:
+    parts = [part for part in full_name.strip().split(" ") if part]
+    if not parts:
+        return ""
+
+    masked_parts: List[str] = []
+    for index, part in enumerate(parts):
+        first_letter = part[0]
+        if index == 0:
+            masked = first_letter + "***" if len(part) > 1 else first_letter
+        else:
+            masked = f"{first_letter}."
+        masked_parts.append(masked)
+    return " ".join(masked_parts)
+
+
+def make_ticket_hash(ticket_number: str) -> str:
+    digest = hashlib.sha256(ticket_number.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def make_passenger_id(ticket_number: str, passenger_name: str) -> str:
+    digest = hashlib.sha256(f"{ticket_number}|{passenger_name}".encode("utf-8")).hexdigest()
+    return f"pax_{digest[:12]}"
+
+
+def make_flight_id(flight: FlightDetails) -> str:
+    digest = hashlib.sha256(f"{flight.iata}|{flight.std.isoformat()}".encode("utf-8")).hexdigest()
+    return f"flt_{digest[:12]}"
+
+
+@app.post("/lookup", response_model=LookupResponse)
+def lookup_booking(payload: LookupRequest) -> LookupResponse:
+    identifier = payload.ticket_or_pnr.strip()
+    logger.info("Lookup requested for identifier=%s", identifier)
+
+    booking = MOCK_REPOSITORY.get(identifier)
+    if booking is None:
+        logger.error("Booking not found for identifier=%s", identifier)
+        raise HTTPException(status_code=404, detail="Booking not found")
+
+    ticket_hash = make_ticket_hash(booking.ticket_number)
+    passenger_id = make_passenger_id(booking.ticket_number, booking.passenger_name)
+    flight_id = make_flight_id(booking.flight)
+    response = LookupResponse(
+        passenger_id=passenger_id,
+        passenger_masked=mask_passenger_name(booking.passenger_name),
+        ticket_hash=ticket_hash,
+        ticket_last4=booking.ticket_number[-4:],
+        flight_id=flight_id,
+        flight=FlightSchema(iata=booking.flight.iata, std=booking.flight.std),
+        service_suggestions=list(booking.service_suggestions),
+    )
+
+    logger.info("Lookup succeeded for identifier=%s", identifier)
+    return response
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Basic health endpoint for container orchestration."""
+    return {"status": "ok"}

--- a/services/booking-lookup/requirements.txt
+++ b/services/booking-lookup/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+pydantic[email]==2.7.4
+pytest==8.2.2
+httpx==0.27.0

--- a/services/booking-lookup/tests/test_lookup.py
+++ b/services/booking-lookup/tests/test_lookup.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app, make_passenger_id, make_ticket_hash, mask_passenger_name  # noqa: E402
+
+
+client = TestClient(app)
+
+
+def test_mask_passenger_name():
+    assert mask_passenger_name("Иванов Иван") == "И*** И."
+    assert mask_passenger_name(" Петров  Петр  ") == "П*** П."
+    assert mask_passenger_name("") == ""
+
+
+def test_lookup_is_deterministic():
+    payload = {"ticket_or_pnr": "555-1234567890"}
+    first = client.post("/lookup", json=payload).json()
+    second = client.post("/lookup", json=payload).json()
+    assert first == second
+    assert first["ticket_hash"] == make_ticket_hash("555-1234567890")
+    assert first["passenger_id"] == make_passenger_id("555-1234567890", "Иванов Иван")
+
+
+def test_lookup_not_found():
+    response = client.post("/lookup", json={"ticket_or_pnr": "unknown"})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Booking not found"


### PR DESCRIPTION
## Summary
- introduce a new FastAPI-based booking-lookup service that normalises passenger, ticket and flight details from a mock repository
- expose a POST /lookup endpoint with deterministic masking and hashing logic plus a health check
- add unit tests covering name masking, deterministic output, and error handling and wire the service into docker-compose

## Testing
- pytest services/booking-lookup/tests

------
https://chatgpt.com/codex/tasks/task_e_68ca8d0b94f48320a47f0beda721254d