### PR TITLE
Add flight-catalog service for managing flights

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,5 +48,18 @@ services:
     command: bash -lc "pip install --no-cache-dir -r requirements.txt && uvicorn app.main:app --host 0.0.0.0 --port 8200 --reload"
     ports: ["8200:8200"]
 
+  flight-catalog:
+    image: python:3.12-slim
+    working_dir: /app
+    environment:
+      DB_HOST: postgres
+    volumes:
+      - ./services/flight-catalog:/app
+    command: bash -lc "pip install --no-cache-dir -r requirements.txt && uvicorn app.main:app --host 0.0.0.0 --port 8300 --reload"
+    ports: ["8300:8300"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   pg_data:

--- a/services/flight-catalog/app/db.py
+++ b/services/flight-catalog/app/db.py
@@ -1,0 +1,49 @@
+"""Database utilities for the flight-catalog service."""
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+
+DEFAULT_DB_USER = "airport"
+DEFAULT_DB_PASSWORD = "airport"
+DEFAULT_DB_HOST = "localhost"
+DEFAULT_DB_PORT = "5432"
+DEFAULT_DB_NAME = "airport"
+
+
+def _build_default_dsn() -> str:
+    user = os.getenv("DB_USER", DEFAULT_DB_USER)
+    password = os.getenv("DB_PASSWORD", DEFAULT_DB_PASSWORD)
+    host = os.getenv("DB_HOST", DEFAULT_DB_HOST)
+    port = os.getenv("DB_PORT", DEFAULT_DB_PORT)
+    name = os.getenv("DB_NAME", DEFAULT_DB_NAME)
+    return f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{name}"
+
+
+def get_database_dsn() -> str:
+    """Return the database DSN configured via environment or defaults."""
+
+    return os.getenv("DB_DSN", _build_default_dsn())
+
+
+engine = create_async_engine(get_database_dsn(), pool_pre_ping=True)
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy models."""
+
+    pass
+
+
+async def init_db() -> None:
+    """Create database tables for the MVP if they are missing."""
+
+    from . import models  # noqa: F401  ensure metadata is imported
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/services/flight-catalog/app/main.py
+++ b/services/flight-catalog/app/main.py
@@ -1,0 +1,76 @@
+"""FastAPI application exposing the flight-catalog API."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+
+from .db import SessionLocal, init_db
+from .models import Flight
+from .schemas import FlightResponse, FlightUpsertRequest
+from .service import get_flight, search_flights, upsert_flight
+
+app = FastAPI(title="Flight Catalog", version="0.1.0")
+
+
+async def get_db():
+    async with SessionLocal() as session:
+        yield session
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_db()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+def _ensure_timezone(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    if getattr(dt, "tzinfo", None) is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _to_response_model(flight: Flight) -> FlightResponse:
+    return FlightResponse(
+        flight_id=flight.flight_id,
+        iata=flight.iata,
+        std=_ensure_timezone(flight.std),
+        sta=_ensure_timezone(flight.sta),
+        status=flight.status,
+        status_reason=flight.status_reason,
+        last_updated_at=_ensure_timezone(flight.last_updated_at),
+    )
+
+
+@app.get("/flights/{flight_id}", response_model=FlightResponse)
+async def get_flight_by_id(flight_id: str, db=Depends(get_db)) -> FlightResponse:
+    flight = await get_flight(db, flight_id)
+    if flight is None:
+        raise HTTPException(status_code=404, detail="Flight not found")
+    return _to_response_model(flight)
+
+
+@app.get("/flights", response_model=List[FlightResponse])
+async def find_flights(
+    iata: str = Query(..., description="Flight IATA code"),
+    date_value: date = Query(..., alias="date", description="STD date (UTC)"),
+    db=Depends(get_db),
+) -> List[FlightResponse]:
+    flights = await search_flights(db, iata, date_value)
+    return [_to_response_model(f) for f in flights]
+
+
+@app.post("/flights", response_model=FlightResponse)
+async def create_or_update_flight(payload: FlightUpsertRequest, db=Depends(get_db)) -> FlightResponse:
+    flight, _ = await upsert_flight(db, payload)
+    return _to_response_model(flight)
+
+

--- a/services/flight-catalog/app/models.py
+++ b/services/flight-catalog/app/models.py
@@ -1,0 +1,53 @@
+"""SQLAlchemy models for the flight-catalog service."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from enum import Enum
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .db import Base
+
+
+class FlightStatus(str, Enum):  # type: ignore[misc]
+    """Enumeration of supported flight statuses."""
+
+    SCHEDULED = "SCHEDULED"
+    DELAYED = "DELAYED"
+    CANCELLED = "CANCELLED"
+    DEPARTED = "DEPARTED"
+    LANDED = "LANDED"
+
+
+class Flight(Base):
+    """Flight entity stored in the catalogue."""
+
+    __tablename__ = "flights"
+
+    flight_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    iata: Mapped[str] = mapped_column(String(16), nullable=False, index=True)
+    std: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    sta: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    status: Mapped[str] = mapped_column(String(16), nullable=False, index=True)
+    status_reason: Mapped[str | None] = mapped_column(String(255))
+    last_updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+
+    events: Mapped[list["FlightEvent"]] = relationship(back_populates="flight", cascade="all, delete-orphan")
+
+
+class FlightEvent(Base):
+    """Event emitted for flight changes (stored for the MVP)."""
+
+    __tablename__ = "flight_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(default=uuid.uuid4, primary_key=True)
+    flight_id: Mapped[str] = mapped_column(ForeignKey("flights.flight_id", ondelete="CASCADE"), nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    payload: Mapped[dict | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+
+    flight: Mapped[Flight] = relationship(back_populates="events")

--- a/services/flight-catalog/app/schemas.py
+++ b/services/flight-catalog/app/schemas.py
@@ -1,0 +1,50 @@
+"""Pydantic schemas for the flight-catalog service."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from .models import FlightStatus
+
+
+class FlightBase(BaseModel):
+    iata: str = Field(..., description="Flight IATA code", min_length=2)
+    std: datetime = Field(..., description="Scheduled time of departure")
+    sta: Optional[datetime] = Field(None, description="Scheduled time of arrival")
+    status: FlightStatus = Field(..., description="Current status of the flight")
+    status_reason: Optional[str] = Field(
+        None, description="Optional reason for the current flight status"
+    )
+
+
+class FlightUpsertRequest(FlightBase):
+    flight_id: Optional[str] = Field(
+        default=None,
+        description="Internal flight identifier. If omitted it will be derived from IATA+STD.",
+    )
+
+
+class FlightResponse(FlightBase):
+    flight_id: str
+    last_updated_at: datetime
+
+
+class FlightSearchQuery(BaseModel):
+    iata: str
+    date: date
+
+
+class FlightEventResponse(BaseModel):
+    id: str
+    flight_id: str
+    event_type: str
+    payload: dict | None
+    created_at: datetime
+
+
+class UpsertResult(BaseModel):
+    flight: FlightResponse
+    event_type: str | None

--- a/services/flight-catalog/app/service.py
+++ b/services/flight-catalog/app/service.py
@@ -1,0 +1,142 @@
+"""Domain services for managing flights and events."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timezone
+from typing import Optional
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Flight, FlightEvent, FlightStatus
+from .schemas import FlightUpsertRequest
+
+
+def make_flight_id(iata: str, std: datetime) -> str:
+    """Derive a stable flight identifier from IATA code and STD."""
+
+    digest = hashlib.sha256(f"{iata}|{std.isoformat()}".encode("utf-8")).hexdigest()
+    return f"flt_{digest[:12]}"
+
+
+async def get_flight(db: AsyncSession, flight_id: str) -> Optional[Flight]:
+    return await db.get(Flight, flight_id)
+
+
+async def search_flights(db: AsyncSession, iata: str, flight_date: date) -> list[Flight]:
+    start = datetime.combine(flight_date, datetime.min.time(), tzinfo=timezone.utc)
+    end = datetime.combine(flight_date, datetime.max.time(), tzinfo=timezone.utc)
+    stmt = (
+        select(Flight)
+        .where(
+            and_(
+                Flight.iata == iata,
+                Flight.std >= start,
+                Flight.std <= end,
+            )
+        )
+        .order_by(Flight.std.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _json_safe(value: object | None) -> object | None:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, FlightStatus):
+        return value.value
+    return value
+
+
+def _detect_changes(old: Flight, new_data: FlightUpsertRequest) -> dict:
+    """Return a mapping of changed fields with old/new values."""
+
+    changes: dict[str, dict[str, object | None]] = {}
+    tracked_fields = ("iata", "std", "sta", "status", "status_reason")
+    for field in tracked_fields:
+        old_value = getattr(old, field)
+        new_value = getattr(new_data, field)
+        if field == "status" and new_value is not None:
+            new_value = new_value.value
+        if old_value != new_value:
+            changes[field] = {
+                "old": _json_safe(old_value),
+                "new": _json_safe(new_value),
+            }
+    return changes
+
+
+async def upsert_flight(db: AsyncSession, payload: FlightUpsertRequest) -> tuple[Flight, str | None]:
+    """Create or update a flight and register an event for the change."""
+
+    flight_id = payload.flight_id or make_flight_id(payload.iata, payload.std)
+    now = datetime.now(timezone.utc)
+
+    flight = await get_flight(db, flight_id)
+    event_type: str | None = None
+    event_payload: dict[str, object | None] | None = None
+
+    if flight is None:
+        flight = Flight(
+            flight_id=flight_id,
+            iata=payload.iata,
+            std=payload.std,
+            sta=payload.sta,
+            status=payload.status.value,
+            status_reason=payload.status_reason,
+            last_updated_at=now,
+        )
+        db.add(flight)
+        event_type = "flight.created"
+        event_payload = {
+            "flight_id": flight_id,
+            "iata": payload.iata,
+            "std": payload.std.isoformat(),
+            "sta": payload.sta.isoformat() if payload.sta else None,
+            "status": payload.status.value,
+            "status_reason": payload.status_reason,
+        }
+    else:
+        changes = _detect_changes(flight, payload)
+        if changes:
+            previous_status = flight.status
+            flight.iata = payload.iata
+            flight.std = payload.std
+            flight.sta = payload.sta
+            flight.status = payload.status.value
+            flight.status_reason = payload.status_reason
+            flight.last_updated_at = now
+
+            if previous_status != FlightStatus.CANCELLED.value and payload.status is FlightStatus.CANCELLED:
+                event_type = "flight.cancelled"
+                event_payload = {
+                    "flight_id": flight_id,
+                    "previous_status": previous_status,
+                    "status": payload.status.value,
+                    "status_reason": payload.status_reason,
+                }
+            else:
+                event_type = "flight.updated"
+                event_payload = {
+                    "flight_id": flight_id,
+                    "changes": changes,
+                }
+        else:
+            flight.last_updated_at = now
+
+    flight.last_updated_at = now
+
+    if event_type is not None:
+        event = FlightEvent(
+            flight_id=flight_id,
+            event_type=event_type,
+            payload=event_payload,
+            created_at=now,
+        )
+        db.add(event)
+
+    await db.commit()
+    await db.refresh(flight)
+    return flight, event_type

--- a/services/flight-catalog/requirements.txt
+++ b/services/flight-catalog/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+pydantic==2.7.4
+SQLAlchemy[asyncio]==2.0.30
+asyncpg==0.29.0
+aiosqlite==0.20.0
+httpx==0.27.0
+pytest==8.2.2
+pytest-asyncio==0.23.7
+asgi-lifespan==1.0.1

--- a/services/flight-catalog/tests/test_flights.py
+++ b/services/flight-catalog/tests/test_flights.py
@@ -1,0 +1,111 @@
+"""Integration tests for the flight-catalog FastAPI service."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.append(str(SERVICE_ROOT))
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def app_context(monkeypatch, tmp_path):
+    db_path = tmp_path / "flights.sqlite"
+    monkeypatch.setenv("DB_DSN", f"sqlite+aiosqlite:///{db_path}")
+
+    for module in ["app.models", "app.db", "app.main"]:
+        if module in sys.modules:
+            del sys.modules[module]
+
+    app_main = importlib.import_module("app.main")
+    app_db = importlib.import_module("app.db")
+    app_models = importlib.import_module("app.models")
+
+    return app_main.app, app_db.SessionLocal, app_models.FlightEvent
+
+
+@pytest_asyncio.fixture()
+async def client(app_context):
+    app, _, _ = app_context
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            yield client
+
+
+async def test_create_and_fetch_flight(app_context, client):
+    _, _, _ = app_context
+
+    payload = {
+        "iata": "SU123",
+        "std": "2025-09-17T10:00:00+00:00",
+        "sta": "2025-09-17T12:00:00+00:00",
+        "status": "SCHEDULED",
+        "status_reason": None,
+    }
+    response = await client.post("/flights", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["iata"] == "SU123"
+    assert data["status"] == "SCHEDULED"
+
+    flight_id = data["flight_id"]
+    response = await client.get(f"/flights/{flight_id}")
+    assert response.status_code == 200
+    fetched = response.json()
+    assert fetched["flight_id"] == flight_id
+    assert datetime.fromisoformat(fetched["sta"].replace("Z", "+00:00")) == datetime.fromisoformat(
+        "2025-09-17T12:00:00+00:00"
+    )
+
+    search_response = await client.get(
+        "/flights", params={"iata": "SU123", "date": "2025-09-17"}
+    )
+    assert search_response.status_code == 200
+    results = search_response.json()
+    assert len(results) == 1
+    assert results[0]["flight_id"] == flight_id
+
+
+async def test_update_creates_cancel_event(app_context, client):
+    _, session_factory, event_model = app_context
+
+    payload = {
+        "iata": "SU777",
+        "std": "2025-12-24T18:00:00+00:00",
+        "sta": None,
+        "status": "SCHEDULED",
+        "status_reason": None,
+    }
+    create_response = await client.post("/flights", json=payload)
+    assert create_response.status_code == 200
+    flight_id = create_response.json()["flight_id"]
+
+    update_payload = {
+        **payload,
+        "flight_id": flight_id,
+        "status": "CANCELLED",
+        "status_reason": "WEATHER",
+    }
+    update_response = await client.post("/flights", json=update_payload)
+    assert update_response.status_code == 200
+    assert update_response.json()["status"] == "CANCELLED"
+
+    async with session_factory() as session:
+        result = await session.execute(select(event_model).order_by(event_model.created_at))
+        events = list(result.scalars())
+        assert len(events) == 2
+        assert events[-1].event_type == "flight.cancelled"
+        assert events[-1].payload["status_reason"] == "WEATHER"


### PR DESCRIPTION
## Summary
- add a new flight-catalog FastAPI service with async PostgreSQL storage for flights and change events
- expose REST endpoints to fetch, search, and upsert flights while normalising timestamps
- capture flight change events in the database and seed integration tests plus docker-compose wiring and dependencies

## Testing
- `pytest services/flight-catalog/tests -q`
- `pytest services/booking-lookup/tests -q`
- `pytest services/provider-tasking/tests -q` *(fails: existing expectation for cancelled transition in provider-tasking)*

------
https://chatgpt.com/codex/tasks/task_e_68ca935a7a988320bcaf7734f7848488